### PR TITLE
Fix paymentToken issue

### DIFF
--- a/packages/react-native-payments/lib/ios/ReactNativePayments.m
+++ b/packages/react-native-payments/lib/ios/ReactNativePayments.m
@@ -318,10 +318,7 @@ RCT_EXPORT_METHOD(handleDetailsUpdate: (NSDictionary *)details
     NSMutableDictionary *paymentResponse = [[NSMutableDictionary alloc]initWithCapacity:3];
     [paymentResponse setObject:transactionId forKey:@"transactionIdentifier"];
     [paymentResponse setObject:paymentData forKey:@"paymentData"];
-
-    if (token) {
-        [paymentResponse setObject:token forKey:@"paymentToken"];
-    }
+    [paymentResponse setObject:(token) ? (token) : (null) forKey:@"paymentToken"];
 
     [self.bridge.eventDispatcher sendDeviceEventWithName:@"NativePayments:onuseraccept"
                                                     body:paymentResponse

--- a/packages/react-native-payments/lib/ios/ReactNativePayments.m
+++ b/packages/react-native-payments/lib/ios/ReactNativePayments.m
@@ -318,7 +318,7 @@ RCT_EXPORT_METHOD(handleDetailsUpdate: (NSDictionary *)details
     NSMutableDictionary *paymentResponse = [[NSMutableDictionary alloc]initWithCapacity:3];
     [paymentResponse setObject:transactionId forKey:@"transactionIdentifier"];
     [paymentResponse setObject:paymentData forKey:@"paymentData"];
-    [paymentResponse setObject:(token) ? (token) : (null) forKey:@"paymentToken"];
+    [paymentResponse setObject:(token) ? (token) : (nil) forKey:@"paymentToken"];
 
     [self.bridge.eventDispatcher sendDeviceEventWithName:@"NativePayments:onuseraccept"
                                                     body:paymentResponse

--- a/packages/react-native-payments/lib/js/PaymentRequest.js
+++ b/packages/react-native-payments/lib/js/PaymentRequest.js
@@ -295,25 +295,29 @@ export default class PaymentRequest {
 
   _getPlatformDetailsIOS(details: {
     transactionIdentifier: string,
-    paymentData: string
+    paymentData: string,
+    paymentToken: string,
   }) {
     const {
       transactionIdentifier,
-      paymentData: serializedPaymentData
+      paymentData: serializedPaymentData,
+      paymentToken
     } = details;
     const isSimulator = transactionIdentifier === 'Simulated Identifier';
 
     if (isSimulator) {
       return Object.assign({}, details, {
         paymentData: null,
-        serializedPaymentData
+        paymentToken: null,
+        serializedPaymentData,
       });
     }
 
     return {
       transactionIdentifier,
       paymentData: JSON.parse(serializedPaymentData),
-      serializedPaymentData
+      paymentToken: paymentToken,
+      serializedPaymentData,
     };
   }
 
@@ -345,7 +349,8 @@ export default class PaymentRequest {
     transactionIdentifier: string,
     paymentData: string,
     shippingAddress: object,
-    payerEmail: string
+    payerEmail: string,
+    paymentToken: string
   }) {
     // On Android, we don't have `onShippingAddressChange` events, so we
     // set the shipping address when the user accepts.
@@ -365,6 +370,7 @@ export default class PaymentRequest {
       shippingOption: IS_IOS ? this._shippingOption : null,
       payerName: this._options.requestPayerName ? this._shippingAddress.recipient : null,
       payerPhone: this._options.requestPayerPhone ? this._shippingAddress.phone : null,
+      paymentToken: details.paymentToken,
       payerEmail: IS_ANDROID && this._options.requestPayerEmail
         ? details.payerEmail
         : null


### PR DESCRIPTION
This took me a while to figure out, but it seems that while the native code is returning back the `paymentToken` if the gateway requires nonce tokenization (in my case: braintree) the javascript just drops the dictionary key when it gets the response back from native code. 

This PR makes sure that `paymentToken` is always passed back in the dictionary (even if it's `null`) and changes the response from JS to include the key/value so we can use it.