### PR TITLE
Fix issue when `paymentToken` is not present on real iOS device.

### DIFF
--- a/packages/react-native-payments-addon-braintree/Cartfile
+++ b/packages/react-native-payments-addon-braintree/Cartfile
@@ -1,1 +1,1 @@
-github "braintree/braintree_ios" == 4.8.4
+github "braintree/braintree_ios" == 4.9.4

--- a/packages/react-native-payments-addon-braintree/Cartfile.resolved
+++ b/packages/react-native-payments-addon-braintree/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "braintree/braintree_ios" "4.8.4"
+github "braintree/braintree_ios" "4.9.4"

--- a/packages/react-native-payments/lib/ios/ReactNativePayments.m
+++ b/packages/react-native-payments/lib/ios/ReactNativePayments.m
@@ -203,23 +203,40 @@ RCT_EXPORT_METHOD(handleDetailsUpdate: (NSDictionary *)details
 }
 
 // PRIVATE METHODS
+// https://developer.apple.com/reference/passkit/pkpaymentnetwork
 // ---------------
 - (NSArray *_Nonnull)getSupportedNetworksFromMethodData:(NSDictionary *_Nonnull)methodData
 {
-    // https://developer.apple.com/reference/passkit/pkpaymentnetwork
-    NSDictionary *supportedNetworksMapping = @{
-                                               @"amex": PKPaymentNetworkAmex,
-                                               @"chinaunionpay": PKPaymentNetworkChinaUnionPay,
-                                               @"discover": PKPaymentNetworkDiscover,
-                                               @"jcb": PKPaymentNetworkJCB,
-                                               @"mastercard": PKPaymentNetworkMasterCard,
-                                               @"privatelabel": PKPaymentNetworkPrivateLabel,
-                                               @"visa": PKPaymentNetworkVisa,
-                                               @"interac": PKPaymentNetworkInterac,
-                                               @"suica": PKPaymentNetworkSuica,
-                                               @"quicpay": PKPaymentNetworkQuicPay,
-                                               @"idcredit": PKPaymentNetworkIDCredit
-                                               };
+    NSMutableDictionary *supportedNetworksMapping = [[NSMutableDictionary alloc] init];
+
+    CGFloat iOSVersion = [[[UIDevice currentDevice] systemVersion] floatValue];
+
+    if (iOSVersion >= 8) {
+        [supportedNetworksMapping setObject:PKPaymentNetworkAmex forKey:@"amex"];
+        [supportedNetworksMapping setObject:PKPaymentNetworkMasterCard forKey:@"mastercard"];
+        [supportedNetworksMapping setObject:PKPaymentNetworkVisa forKey:@"visa"];
+    }
+
+    if (iOSVersion >= 9) {
+        [supportedNetworksMapping setObject:PKPaymentNetworkDiscover forKey:@"discover"];
+        [supportedNetworksMapping setObject:PKPaymentNetworkPrivateLabel forKey:@"privatelabel"];
+    }
+
+    if (iOSVersion >= 9.2) {
+        [supportedNetworksMapping setObject:PKPaymentNetworkChinaUnionPay forKey:@"chinaunionpay"];
+        [supportedNetworksMapping setObject:PKPaymentNetworkInterac forKey:@"interac"];
+    }
+
+    if (iOSVersion >= 10.1) {
+        [supportedNetworksMapping setObject:PKPaymentNetworkJCB forKey:@"jcb"];
+        [supportedNetworksMapping setObject:PKPaymentNetworkSuica forKey:@"suica"];
+    }
+
+    if (iOSVersion >= 10.3) {
+        [supportedNetworksMapping setObject:PKPaymentNetworkCarteBancaire forKey:@"cartebancaires"];
+        [supportedNetworksMapping setObject:PKPaymentNetworkIDCredit forKey:@"idcredit"];
+        [supportedNetworksMapping setObject:PKPaymentNetworkQuicPay forKey:@"quicpay"];
+    }
 
     // Setup supportedNetworks
     NSArray *jsSupportedNetworks = methodData[@"supportedNetworks"];


### PR DESCRIPTION
Other changes:
- this commit unifies responses for iOS simulator and real iOS device
- `serializedPaymentData` is no longer present. Data is always deserialised.
- add some Flow types and fix some (e.g `object` -> `Object`)

Fixes #30 