### PR TITLE
[iOS] Fix issue when `paymentToken` is not present on real iOS device.

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,18 +328,20 @@ There are two ways to process Apple Pay/Android Pay payments -- on your server o
 #### Processing Payments on Your Server
 If you're equiped to process Apple Pay/Android Pay payments on your server, all you have to do is send the Payment Response data to your server.
 
+> ⚠️ **Note:** When running Apple Pay on simulator, `paymentData` equals to `null`.
+
 ```es6
 import { NativeModules } from 'react-native';
 
 paymentRequest.show()
   .then(paymentResponse => {
-    const { transactionIdentifier, serializedPaymentData } = paymentResponse.details;
+    const { transactionIdentifier, paymentData } = paymentResponse.details;
 
     return fetch('...', {
       method: 'POST',
       body: {
         transactionIdentifier,
-        serializedPaymentData
+        paymentData
       }
     })
     .then(res => res.json())

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ __Features__
 - [Demo](#demo)
 - [Installation](#installation)
 - [Usage](#usage)
+- [Testing Payments](#testing-payments)
 - [Add-ons](#add-ons)
 - [API](#api)
 - [Resources](#resources)
@@ -439,6 +440,15 @@ paymentResponse.complete('success'); // Alternatively, you can call it with `fai
 ```
 
 🚨 _Note: On Android, there is no need to call `paymentResponse.complete` -- the PaymentRequest dismisses itself._
+
+## Testing Payments
+
+### Apple Pay
+
+The sandbox environment is a great way to test offline implementation of Apple Pay for apps, websites, and point of sale systems. Apple offers [detailed guide](https://developer.apple.com/support/apple-pay-sandbox/) for setting up sandbox environment.
+> ⚠️ **Note:** It is also important to test Apple Pay in your production environment. Real cards must be used in the production environment. Test cards will not work.
+>
+> ⚠️ **Note:** There are known differences when running Apple Pay on simulator and real device. Make sure you test Apple Pay on real device before going into production.
 
 ## Add-ons
 Here's a list of Payment Processors that you can enable via add-ons:

--- a/packages/react-native-payments/lib/js/PaymentRequest.js
+++ b/packages/react-native-payments/lib/js/PaymentRequest.js
@@ -11,7 +11,9 @@ import type {
   PaymentShippingOption,
   PaymentItem,
   PaymentAddress,
-  PaymentShippingType
+  PaymentShippingType,
+  PaymentDetailsIOS,
+  PaymentDetailsIOSRaw,
 } from './types';
 import type PaymentResponseType from './PaymentResponse';
 
@@ -53,18 +55,6 @@ import {
   GATEWAY_ERROR_EVENT,
   SUPPORTED_METHOD_NAME
 } from './constants';
-
-type PaymentDetailsIOS = {
-  paymentData: ?Object,
-  paymentToken?: string,
-  transactionIdentifier: string,
-};
-
-type PaymentDetailsIOSRaw = {
-  paymentData: string,
-  paymentToken?: string,
-  transactionIdentifier: string,
-};
 
 const noop = () => {};
 const IS_ANDROID = Platform.OS === 'android';

--- a/packages/react-native-payments/lib/js/types.js
+++ b/packages/react-native-payments/lib/js/types.js
@@ -85,3 +85,15 @@ export type PaymentShippingOption = {
 
 // https://www.w3.org/TR/payment-request/#paymentcomplete-enum
 export type PaymentComplete = 'fail' | 'success' | 'unknown';
+
+export type PaymentDetailsIOS = {
+  paymentData: ?Object,
+  paymentToken?: string,
+  transactionIdentifier: string,
+};
+
+export type PaymentDetailsIOSRaw = {
+  paymentData: string,
+  paymentToken?: string,
+  transactionIdentifier: string,
+};


### PR DESCRIPTION
Other changes:
- this commit unifies responses for iOS simulator and real iOS device
- `serializedPaymentData` is no longer present. Data is always deserialised.
- add some Flow types and fix some (e.g `object` -> `Object`)

Fixes #30