### PR TITLE
[iOS] Update `braintree_ios` dependency to latest version.

### DIFF
--- a/packages/react-native-payments-addon-braintree/Cartfile
+++ b/packages/react-native-payments-addon-braintree/Cartfile
@@ -1,1 +1,1 @@
-github "braintree/braintree_ios" == 4.8.4
+github "braintree/braintree_ios" == 4.9.4

--- a/packages/react-native-payments-addon-braintree/Cartfile.resolved
+++ b/packages/react-native-payments-addon-braintree/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "braintree/braintree_ios" "4.8.4"
+github "braintree/braintree_ios" "4.9.4"


### PR DESCRIPTION
Current versions fails to parse tokenization key in production environment.

Fixes #35