### PR TITLE
Do not fail if native module is unavailable

### DIFF
--- a/packages/react-native-payments/lib/js/NativePayments.js
+++ b/packages/react-native-payments/lib/js/NativePayments.js
@@ -19,7 +19,7 @@ const NativePayments: {
 } = {
   supportedGateways: IS_ANDROID
     ? ['stripe', 'braintree'] // On Android, Payment Gateways are supported out of the gate.
-    : ReactNativePayments.supportedGateways,
+    : ReactNativePayments ? ReactNativePayments.supportedGateways : [],
 
   canMakePayments(methodData: object) {
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
For example, when running in a JavaScript test runner, the native addons do not exist, but a simple import of the module should not fail.