### PR TITLE
Fix loss of exception in NativePayments.show()

### DIFF
--- a/packages/react-native-payments/lib/js/PaymentRequest.js
+++ b/packages/react-native-payments/lib/js/PaymentRequest.js
@@ -448,7 +448,8 @@ export default class PaymentRequest {
       const normalizedDetails = convertDetailAmountsToString(this._details);
       const options = this._options;
 
-      return NativePayments.show(platformMethodData, normalizedDetails, options);
+      // Note: resolve will be triggered via _acceptPromiseResolver() from somwhere else
+      NativePayments.show(platformMethodData, normalizedDetails, options).catch(reject);
     });
 
     return this._acceptPromise;


### PR DESCRIPTION
Correctly pass on promise failure of NativePayments.show()

Without this, if show() fails (for example, when AndroidPay fails with error 405 because you are running with debug signing keys but do not set environment=TEST), the exception will not be passed on.

This is a bit messy, because of the way the NativePayments.show() promise can never succeed from the native side (I wonder if there is a memory leak there somewhere?), so I added a comment.