### PR TITLE
fix(typo): spelling of paymentToken

### DIFF
--- a/packages/react-native-payments/lib/js/NativePayments.js
+++ b/packages/react-native-payments/lib/js/NativePayments.js
@@ -148,9 +148,12 @@ const NativePayments: {
         paymentMethodData,
         details,
         (err) => reject(err),
-        (serializedPaymenToken) => resolve({
-          serializedPaymenToken,
-          paymenToken: JSON.parse(serializedPaymenToken)
+        (serializedPaymentToken) => resolve({
+          serializedPaymentToken,
+          paymentToken: JSON.parse(serializedPaymentToken),
+          /** Leave previous typo in order not to create a breaking change **/
+          serializedPaymenToken: serializedPaymentToken,
+          paymenToken: JSON.parse(serializedPaymentToken)
         })
       );
     });


### PR DESCRIPTION
Fixes a typo in the spelling of `paymentToken`. 