### PR TITLE
fix: payment token for iOS

### DIFF
--- a/packages/react-native-payments/lib/js/PaymentRequest.js
+++ b/packages/react-native-payments/lib/js/PaymentRequest.js
@@ -299,6 +299,7 @@ export default class PaymentRequest {
   }) {
     const {
       transactionIdentifier,
+      paymentToken,
       paymentData: serializedPaymentData
     } = details;
     const isSimulator = transactionIdentifier === 'Simulated Identifier';
@@ -312,6 +313,7 @@ export default class PaymentRequest {
 
     return {
       transactionIdentifier,
+      paymentToken,
       paymentData: JSON.parse(serializedPaymentData),
       serializedPaymentData
     };


### PR DESCRIPTION
payment token for iOS when using stripe was not being returned to the user when handed back from the iOS lib