### PR TITLE
Fix/braintree ios

### DIFF
--- a/packages/react-native-payments-addon-braintree/Cartfile
+++ b/packages/react-native-payments-addon-braintree/Cartfile
@@ -1,1 +1,1 @@
-github "braintree/braintree_ios" == 4.9.4
+github "braintree/braintree_ios" == 4.9.6

--- a/packages/react-native-payments-addon-braintree/Cartfile
+++ b/packages/react-native-payments-addon-braintree/Cartfile
@@ -1,1 +1,1 @@
-github "braintree/braintree_ios" == 4.8.4
+github "braintree/braintree_ios" == 4.9.4

--- a/packages/react-native-payments-addon-braintree/Cartfile.resolved
+++ b/packages/react-native-payments-addon-braintree/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "braintree/braintree_ios" "4.9.4"
+github "braintree/braintree_ios" "4.9.6"

--- a/packages/react-native-payments-addon-braintree/Cartfile.resolved
+++ b/packages/react-native-payments-addon-braintree/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "braintree/braintree_ios" "4.8.4"
+github "braintree/braintree_ios" "4.9.4"


### PR DESCRIPTION
Again, build of Braintree addons was failing. Updating `braintree_ios` dependency solve the issue.