### PR TITLE
fix podspec

### DIFF
--- a/packages/react-native-payments/lib/ios/ReactNativePayments.podspec
+++ b/packages/react-native-payments/lib/ios/ReactNativePayments.podspec
@@ -1,18 +1,22 @@
+require "json"
+
+package = JSON.parse(File.read(File.join(__dir__, "../../package.json")))
+version = package["version"]
+giturl = package["repository"]
 
 Pod::Spec.new do |s|
   s.name         = "ReactNativePayments"
-  s.version      = "1.0.0"
-  s.summary      = "ReactNativePayments"
+  s.version      = version
+  s.summary      = "react-native-payments"
   s.description  = <<-DESC
-                  ReactNativePayments
+                  Native Payments (Google and Apple Pay) from React-Native
                    DESC
-  s.homepage     = ""
+  s.homepage     = giturl
   s.license      = "MIT"
-  # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
-  s.author             = { "author" => "author@domain.cn" }
+  s.author       = "Naoufal Kadhom"
   s.platform     = :ios, "7.0"
-  s.source       = { :git => "https://github.com/author/ReactNativePayments.git", :tag => "master" }
-  s.source_files  = "ReactNativePayments/**/*.{h,m}"
+  s.source       = { :git => giturl + ".git", :tag => version }
+  s.source_files  = "*.{h,m}"
   s.requires_arc = true
 
 
@@ -20,5 +24,3 @@ Pod::Spec.new do |s|
   #s.dependency "others"
 
 end
-
-  


### PR DESCRIPTION
The existing podspec cannot be used with recent CocoaPods (empty `homepage`) and doesn't find any files, since they are directly in `lib/ios` and not `lib/ios/ReactNativePayments`.

**NOTE:** do **NOT** send the podspec to cocoapods repo! Users must use the local `../node_modules` path.

# Instructions

In your `ios/Podfile` make sure to use `ReactNativePayments` from the local
`node_modules/`. With that, only your project Pod needs to be linked and
no extra configuration is required:

```ruby
target 'MyReactApp' do
  # Make sure you're also using React-Native from ../node_modules
  pod 'React', :path => '../node_modules/react-native', :subspecs => [
    'Core',
    'RCTActionSheet',
	# ... whatever else you use
  ]
  # React-Native dependencies such as yoga:
  pod 'yoga', path: '../node_modules/react-native/ReactCommon/yoga'

  # The following line uses ReactNativePayments, linking with
  # the library and setting the Header Search Paths for you
  pod 'ReactNativePayments', :path => '../node_modules/react-native-payments/lib/ios'
end
```

Remember to run `cd ios && pod install` to update files used by Xcode.