### PR TITLE
Update list of supported Google Pay gateways.

### DIFF
--- a/packages/react-native-payments/lib/js/NativePayments.js
+++ b/packages/react-native-payments/lib/js/NativePayments.js
@@ -7,6 +7,21 @@ const { ReactNativePayments } = NativeModules;
 
 const IS_ANDROID = Platform.OS === 'android';
 
+// https://developers.google.com/pay/api/#participating-google-pay-processors
+const androidSupportedGateways = [
+  'adyen',
+  'braintree',
+  'cloudpayments',
+  'ebanx',
+  'firstdata',
+  'imsolutions',
+  'paysafe',
+  'payture',
+  'stripe',
+  'vantiv',
+  'worldpay',
+];
+
 const NativePayments: {
   canMakePayments: boolean,
   supportedGateways: Array<string>,
@@ -18,7 +33,7 @@ const NativePayments: {
   getFullWalletAndroid: string => Promise<any>
 } = {
   supportedGateways: IS_ANDROID
-    ? ['stripe', 'braintree'] // On Android, Payment Gateways are supported out of the gate.
+    ? androidSupportedGateways
     : ReactNativePayments.supportedGateways,
 
   canMakePayments(methodData: object) {


### PR DESCRIPTION
There are more gateways, not just braintree and stripe.
