### PR TITLE
Change NativePayments.complete resolution to promise

### DIFF
--- a/packages/react-native-payments/lib/js/PaymentResponse.js
+++ b/packages/react-native-payments/lib/js/PaymentResponse.js
@@ -86,8 +86,10 @@ export default class PaymentResponse {
     this._completeCalled = true;
 
     return new Promise((resolve, reject) => {
-      return NativePayments.complete(paymentStatus, () => {
-        return resolve(undefined);
+      return NativePayments.complete(paymentStatus).then(() => {
+        resolve(undefined);
+      }).catch((error) => {
+        reject(error)
       });
     });
   }


### PR DESCRIPTION
Think this may have been clobbered by a merge  somewhere along the way - the removed callback no longer exists.  

