### PR TITLE
PaymentRequest: catch promise errors

### DIFF
--- a/packages/react-native-payments/lib/js/PaymentRequest.js
+++ b/packages/react-native-payments/lib/js/PaymentRequest.js
@@ -442,7 +442,7 @@ export default class PaymentRequest {
       const normalizedDetails = convertDetailAmountsToString(this._details);
       const options = this._options;
 
-      return NativePayments.show(platformMethodData, normalizedDetails, options);
+      NativePayments.show(platformMethodData, normalizedDetails, options).catch(reject);
     });
 
     return this._acceptPromise;


### PR DESCRIPTION
Since the promise executor return value is ignore according to the
JS spec, the promise returned by NativePayments.show() must
be treated. This was causing the PaymentRequest.show() promise
to never be rejected in some cases, which would lead in a
inifinite waiting.