### PR TITLE
Added static PaymentRequest.canMakePaymentsUsingNetworks method

### DIFF
--- a/packages/react-native-payments/docs/NativePayments.md
+++ b/packages/react-native-payments/docs/NativePayments.md
@@ -133,6 +133,31 @@ NativePayments.canMakePayments();
 
 ---
 
+### canMakePaymentsUsingNetworks()
+**(IOS only)** Returns if user has available cards at Apple Pay that matches passed networks.
+
+__Arguments__
+- usingNetworks - `Array`
+
+
+<details>
+<summary>
+<strong>Example</strong>
+</summary>
+
+```es6
+NativePayments
+    .canMakePaymentsUsingNetworks(['Visa', 'AmEx', 'MasterCard'])
+    .then(canMakePayments => {
+        if (canMakePayments) {
+            // do some stuff
+        }
+    });
+```
+
+</details>
+
+
 ### show()
 Displays Apple Pay/Android Pay to the user.
 

--- a/packages/react-native-payments/docs/PaymentRequest.md
+++ b/packages/react-native-payments/docs/PaymentRequest.md
@@ -91,6 +91,29 @@ paymentRequest.canMakePayments()
 
 ---
 
+### static canMakePaymentsUsingNetworks()
+**(IOS only)** Determines if user has active cards in Apple pay that matches passed networks.
+
+__Arguments__
+- usingNetworks - `Array`
+
+<details>
+<summary><strong>Example</strong></summary>
+
+```es6
+PaymentRequest
+    .canMakePaymentsUsingNetworks(['Visa', 'AmEx', 'MasterCard'])
+    .then(canMakePayments => {
+        if (canMakePayments) {
+            // do some stuff
+        }
+    });
+```
+
+</details>
+
+---
+
 ### show()
 Displays the payment request to the user.
 

--- a/packages/react-native-payments/lib/ios/ReactNativePayments.m
+++ b/packages/react-native-payments/lib/ios/ReactNativePayments.m
@@ -20,6 +20,13 @@ RCT_EXPORT_MODULE()
              };
 }
 
+RCT_EXPORT_METHOD(canMakePaymentsUsingNetworks:
+                  (NSArray *)paymentNetworks
+                  callback:(RCTResponseSenderBlock)callback)
+{
+    callback(@[[NSNull null], @([PKPaymentAuthorizationViewController canMakePaymentsUsingNetworks:paymentNetworks])]);
+}
+
 RCT_EXPORT_METHOD(createPaymentRequest: (NSDictionary *)methodData
                   details: (NSDictionary *)details
                   options: (NSDictionary *)options

--- a/packages/react-native-payments/lib/js/NativePayments.js
+++ b/packages/react-native-payments/lib/js/NativePayments.js
@@ -9,6 +9,7 @@ const IS_ANDROID = Platform.OS === 'android';
 
 const NativePayments: {
   canMakePayments: boolean,
+  canMakePaymentsUsingNetworks: boolean,
   supportedGateways: Array<string>,
   createPaymentRequest: PaymentDetailsBase => Promise<any>,
   handleDetailsUpdate: PaymentDetailsBase => Promise<any>,
@@ -35,6 +36,22 @@ const NativePayments: {
 
       // On iOS, canMakePayments is exposed as a constant.
       resolve(ReactNativePayments.canMakePayments);
+    });
+  },
+
+  canMakePaymentsUsingNetworks(usingNetworks: []) {
+    // IOS method to check that user has available cards at Apple Pay
+    // https://developer.apple.com/documentation/passkit/pkpaymentauthorizationviewcontroller/1616187-canmakepaymentsusingnetworks?language=occ
+
+    return new Promise((resolve) => {
+      if (IS_ANDROID) {
+        resolve(false);
+      }
+
+      ReactNativePayments.canMakePaymentsUsingNetworks(
+        usingNetworks,
+        (err, data) => resolve(data)
+      );
     });
   },
 

--- a/packages/react-native-payments/lib/js/PaymentRequest.js
+++ b/packages/react-native-payments/lib/js/PaymentRequest.js
@@ -476,5 +476,7 @@ export default class PaymentRequest {
       getPlatformMethodData(JSON.parse(this._serializedMethodData), Platform.OS)
     );
   }
+
+  static canMakePaymentsUsingNetworks = NativePayments.canMakePaymentsUsingNetworks;
 }
 


### PR DESCRIPTION
Added static method PaymentRequest.canMakePaymentsUsingNetworks that allows to detect if user has active cards at Apple Pay.

Reference issue: https://github.com/naoufal/react-native-payments/issues/98