### PR TITLE
Add billingContact and shippingContact to paymentResponse on iOS

### DIFF
--- a/packages/react-native-payments/lib/ios/ReactNativePayments.m
+++ b/packages/react-native-payments/lib/ios/ReactNativePayments.m
@@ -338,6 +338,12 @@ RCT_EXPORT_METHOD(handleDetailsUpdate: (NSDictionary *)details
 
 - (NSString *_Nonnull)contactToString:(PKContact *_Nonnull)contact
 {
+    NSString *namePrefix = contact.name.namePrefix;
+    NSString *givenName = contact.name.givenName;
+    NSString *middleName = contact.name.middleName;
+    NSString *familyName = contact.name.familyName;
+    NSString *nameSuffix = contact.name.nameSuffix;
+    NSString *nickname = contact.name.nickname;
     NSString *street = contact.postalAddress.street;
     NSString *subLocality = contact.postalAddress.subLocality;
     NSString *city = contact.postalAddress.city;
@@ -350,6 +356,14 @@ RCT_EXPORT_METHOD(handleDetailsUpdate: (NSDictionary *)details
     NSString *emailAddress = contact.emailAddress;
     
     NSDictionary *contactDict = @{
+         @"name" : @{
+                 @"namePrefix" : namePrefix ?: @"",
+                 @"givenName" : givenName ?: @"",
+                 @"middleName" : middleName ?: @"",
+                 @"familyName" : familyName ?: @"",
+                 @"nameSuffix" : nameSuffix ?: @"",
+                 @"nickname" : nickname ?: @"",
+         },
          @"postalAddress" : @{
                  @"street" : street ?: @"",
                  @"subLocality" : subLocality ?: @"",
@@ -360,8 +374,8 @@ RCT_EXPORT_METHOD(handleDetailsUpdate: (NSDictionary *)details
                  @"country" : country ?: @"",
                  @"ISOCountryCode" : ISOCountryCode ?: @""
          },
-         @"phoneNumber" : phoneNumber ? phoneNumber : @"",
-         @"emailAddress" : emailAddress ? emailAddress : @""
+         @"phoneNumber" : phoneNumber ?: @"",
+         @"emailAddress" : emailAddress ?: @""
     };
     
     NSError *error;

--- a/packages/react-native-payments/lib/ios/ReactNativePayments.m
+++ b/packages/react-native-payments/lib/ios/ReactNativePayments.m
@@ -318,6 +318,10 @@ RCT_EXPORT_METHOD(handleDetailsUpdate: (NSDictionary *)details
     if (options[@"requestShipping"]) {
         self.paymentRequest.requiredShippingAddressFields = PKAddressFieldPostalAddress;
     }
+
+    if (options[@"requestBilling"]) {
+        self.paymentRequest.requiredBillingAddressFields = PKAddressFieldPostalAddress;
+    }
     
     if (options[@"requestPayerName"]) {
         self.paymentRequest.requiredShippingAddressFields = self.paymentRequest.requiredShippingAddressFields | PKAddressFieldName;
@@ -332,17 +336,64 @@ RCT_EXPORT_METHOD(handleDetailsUpdate: (NSDictionary *)details
     }
 }
 
+- (NSString *_Nonnull)contactToString:(PKContact *_Nonnull)contact
+{
+    NSString *street = contact.postalAddress.street;
+    NSString *subLocality = contact.postalAddress.subLocality;
+    NSString *city = contact.postalAddress.city;
+    NSString *subAdministrativeArea = contact.postalAddress.subAdministrativeArea;
+    NSString *state = contact.postalAddress.state;
+    NSString *postalCode = contact.postalAddress.postalCode;
+    NSString *country = contact.postalAddress.country;
+    NSString *ISOCountryCode = contact.postalAddress.ISOCountryCode;
+    NSString *phoneNumber = contact.phoneNumber.stringValue;
+    NSString *emailAddress = contact.emailAddress;
+    
+    NSDictionary *contactDict = @{
+         @"postalAddress" : @{
+                 @"street" : street ?: @"",
+                 @"subLocality" : subLocality ?: @"",
+                 @"city" : city ?: @"",
+                 @"subAdministrativeArea" : subAdministrativeArea ?: @"",
+                 @"state" : state ?: @"",
+                 @"postalCode" : postalCode ?: @"",
+                 @"country" : country ?: @"",
+                 @"ISOCountryCode" : ISOCountryCode ?: @""
+         },
+         @"phoneNumber" : phoneNumber ? phoneNumber : @"",
+         @"emailAddress" : emailAddress ? emailAddress : @""
+    };
+    
+    NSError *error;
+    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:contactDict options:0 error:&error];
+    
+    if (! jsonData) {
+       return @"";
+    } else {
+       return [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+    }
+    
+}
+
 - (void)handleUserAccept:(PKPayment *_Nonnull)payment
             paymentToken:(NSString *_Nullable)token
 {
     NSString *transactionId = payment.token.transactionIdentifier;
     NSString *paymentData = [[NSString alloc] initWithData:payment.token.paymentData encoding:NSUTF8StringEncoding];
-    NSMutableDictionary *paymentResponse = [[NSMutableDictionary alloc]initWithCapacity:3];
+    NSMutableDictionary *paymentResponse = [[NSMutableDictionary alloc]initWithCapacity:5];
     [paymentResponse setObject:transactionId forKey:@"transactionIdentifier"];
     [paymentResponse setObject:paymentData forKey:@"paymentData"];
-    
+
     if (token) {
         [paymentResponse setObject:token forKey:@"paymentToken"];
+    }
+    
+    if (payment.billingContact) {
+        paymentResponse[@"billingContact"] = [self contactToString:payment.billingContact];
+    }
+   
+    if (payment.shippingContact) {
+        paymentResponse[@"shippingContact"] = [self contactToString:payment.shippingContact];
     }
     
     [self.bridge.eventDispatcher sendDeviceEventWithName:@"NativePayments:onuseraccept"

--- a/packages/react-native-payments/lib/js/PaymentRequest.js
+++ b/packages/react-native-payments/lib/js/PaymentRequest.js
@@ -298,14 +298,33 @@ export default class PaymentRequest {
   _getPlatformDetailsIOS(details: PaymentDetailsIOSRaw): PaymentDetailsIOS {
     const {
       paymentData: serializedPaymentData,
+      billingContact: serializedBillingContact,
+      shippingContact: serializedShippingContact,
       paymentToken,
       transactionIdentifier,
     } = details;
 
     const isSimulator = transactionIdentifier === 'Simulated Identifier';
 
+    let billingContact = null;
+    let shippingContact = null;
+
+    if (serializedBillingContact && serializedBillingContact !== ""){
+      try{
+        billingContact = JSON.parse(serializedBillingContact);
+      }catch(e){}
+    }
+
+    if (serializedShippingContact && serializedShippingContact !== ""){
+      try{
+        shippingContact = JSON.parse(serializedShippingContact);
+      }catch(e){}
+    }
+
     return {
       paymentData: isSimulator ? null : JSON.parse(serializedPaymentData),
+      billingContact,
+      shippingContact,
       paymentToken,
       transactionIdentifier,
     };

--- a/packages/react-native-payments/lib/js/PaymentResponse.js
+++ b/packages/react-native-payments/lib/js/PaymentResponse.js
@@ -4,7 +4,8 @@
 import type {
   PaymentComplete,
   PaymentDetailsInit,
-  PaymentAddress
+  PaymentAddress,
+  PaymentContact
 } from './types';
 
 // Modules
@@ -21,6 +22,8 @@ export default class PaymentResponse {
   _payerPhone: null | string;
   _payerEmail: null | string;
   _completeCalled: boolean;
+  _shippingContact: null | PaymentContact;
+  _billingContact: null | PaymentContact;
 
   constructor(paymentResponse: Object) {
     // Set properties as readOnly
@@ -32,6 +35,8 @@ export default class PaymentResponse {
     this._payerName = paymentResponse.payerName;
     this._payerPhone = paymentResponse.payerPhone;
     this._payerEmail = paymentResponse.payerEmail;
+    this._shippingContact = paymentResponse.shippingContact;
+    this._billingContact = paymentResponse.billingContact;
 
     // Internal Slots
     this._completeCalled = false;
@@ -75,6 +80,14 @@ export default class PaymentResponse {
   // https://www.w3.org/TR/payment-request/#payeremail-attribute
   get payerEmail(): null | string {
     return this._payerEmail;
+  }
+
+  get shippingContact(): PaymentContact {
+    return this._shippingContact;
+  }
+
+  get billingContact(): PaymentContact {
+    return this._billingContact;
   }
 
   // https://www.w3.org/TR/payment-request/#complete-method

--- a/packages/react-native-payments/lib/js/PaymentResponse.js
+++ b/packages/react-native-payments/lib/js/PaymentResponse.js
@@ -4,8 +4,7 @@
 import type {
   PaymentComplete,
   PaymentDetailsInit,
-  PaymentAddress,
-  PaymentContact
+  PaymentAddress
 } from './types';
 
 // Modules
@@ -22,8 +21,6 @@ export default class PaymentResponse {
   _payerPhone: null | string;
   _payerEmail: null | string;
   _completeCalled: boolean;
-  _shippingContact: null | PaymentContact;
-  _billingContact: null | PaymentContact;
 
   constructor(paymentResponse: Object) {
     // Set properties as readOnly
@@ -35,8 +32,6 @@ export default class PaymentResponse {
     this._payerName = paymentResponse.payerName;
     this._payerPhone = paymentResponse.payerPhone;
     this._payerEmail = paymentResponse.payerEmail;
-    this._shippingContact = paymentResponse.shippingContact;
-    this._billingContact = paymentResponse.billingContact;
 
     // Internal Slots
     this._completeCalled = false;
@@ -80,14 +75,6 @@ export default class PaymentResponse {
   // https://www.w3.org/TR/payment-request/#payeremail-attribute
   get payerEmail(): null | string {
     return this._payerEmail;
-  }
-
-  get shippingContact(): PaymentContact {
-    return this._shippingContact;
-  }
-
-  get billingContact(): PaymentContact {
-    return this._billingContact;
   }
 
   // https://www.w3.org/TR/payment-request/#complete-method

--- a/packages/react-native-payments/lib/js/types.js
+++ b/packages/react-native-payments/lib/js/types.js
@@ -102,9 +102,3 @@ export type PaymentDetailsIOSRaw = {
   paymentToken?: string,
   transactionIdentifier: string,
 };
-
-export type PaymentContact = {
-  postalAddress?: ?Object,
-  emailAddress?: string,
-  phoneNumber?: string
-};

--- a/packages/react-native-payments/lib/js/types.js
+++ b/packages/react-native-payments/lib/js/types.js
@@ -50,6 +50,7 @@ export type PaymentOptions = {
   requestPayerEmail: boolean,
   requestPayerPhone: boolean,
   requestShipping: boolean,
+  requestBilling: boolean,
   shippingType: PaymentShippingType
 };
 
@@ -88,12 +89,22 @@ export type PaymentComplete = 'fail' | 'success' | 'unknown';
 
 export type PaymentDetailsIOS = {
   paymentData: ?Object,
+  billingContact?: ?Object,
+  shippingContact?: ?Object,
   paymentToken?: string,
   transactionIdentifier: string,
 };
 
 export type PaymentDetailsIOSRaw = {
   paymentData: string,
+  billingContact?: string,
+  shippingContact?: string,
   paymentToken?: string,
   transactionIdentifier: string,
+};
+
+export type PaymentContact = {
+  postalAddress?: ?Object,
+  emailAddress?: string,
+  phoneNumber?: string
 };


### PR DESCRIPTION
To process an apple pay payment with either shipping address or billing address, the fields billingContact and shippingContact which are returned in the PKPayment are required.

Require billing address with additional option 'requireBilling'.