### PR TITLE
require main queue setup

### DIFF
--- a/packages/react-native-payments/lib/ios/ReactNativePayments.m
+++ b/packages/react-native-payments/lib/ios/ReactNativePayments.m
@@ -12,6 +12,11 @@
 
 RCT_EXPORT_MODULE()
 
++ (BOOL)requiresMainQueueSetup
+{
+  return YES;
+}
+
 - (NSDictionary *)constantsToExport
 {
     return @{


### PR DESCRIPTION
removes warning
we want this anyways since we want to be running on the main thread as well

https://stackoverflow.com/questions/50773748/difference-requiresmainqueuesetup-and-dispatch-get-main-queue