### PR TITLE
(1 line fix) Allow library to be imported from CocoaPods (closes #132)

### DIFF
--- a/packages/react-native-payments/lib/ios/ReactNativePayments.m
+++ b/packages/react-native-payments/lib/ios/ReactNativePayments.m
@@ -248,6 +248,10 @@ RCT_EXPORT_METHOD(handleDetailsUpdate: (NSDictionary *)details
         [supportedNetworksMapping setObject:PKPaymentNetworkCarteBancaires forKey:@"cartebancaires"];
     }
     
+    if (iOSVersion >= 12.1) {
+        [supportedNetworksMapping setObject:PKPaymentNetworkMada forKey:@"mada"];
+    }
+    
     // Setup supportedNetworks
     NSArray *jsSupportedNetworks = methodData[@"supportedNetworks"];
     NSMutableArray *supportedNetworks = [NSMutableArray array];

--- a/packages/react-native-payments/lib/ios/ReactNativePayments.xcodeproj/project.pbxproj
+++ b/packages/react-native-payments/lib/ios/ReactNativePayments.xcodeproj/project.pbxproj
@@ -227,7 +227,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",
-					"$(SRCROOT)/../../../../ios"
+					"$(SRCROOT)/../../../../ios/**"
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
@@ -244,7 +244,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",
-					"$(SRCROOT)/../../../../ios"
+					"$(SRCROOT)/../../../../ios/**"
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";

--- a/packages/react-native-payments/lib/ios/ReactNativePayments.xcodeproj/project.pbxproj
+++ b/packages/react-native-payments/lib/ios/ReactNativePayments.xcodeproj/project.pbxproj
@@ -227,6 +227,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",
+					"$(SRCROOT)/../../../../ios"
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
@@ -243,6 +244,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",
+					"$(SRCROOT)/../../../../ios"
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";

--- a/packages/react-native-payments/package.json
+++ b/packages/react-native-payments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-payments",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "scripts": {
     "run:packager": "cd examples/native && yarn run:packager",
     "run:ios": "cd examples/native && yarn run:ios",


### PR DESCRIPTION
#132 

Hi there, I found a way for this library to work without needing to install the cli and/or Carthage.

We just need to add the standard React Native iOS directory to the header search paths for the project.

The relative path between the node_modules and this ios directory is always the same in React Native projects.

Also, I think it's a good solution because people can continue to use the Carthage process if necessary - both options work!