### PR TITLE
Allow 0 as a total for payment

### DIFF
--- a/packages/react-native-payments/lib/js/helpers/index.js
+++ b/packages/react-native-payments/lib/js/helpers/index.js
@@ -118,7 +118,7 @@ export function validateTotal(total, errorType = Error): void {
     throw new errorType(`required member total is undefined.`);
   }
 
-  const hasTotal = total && total.amount && total.amount.value;
+  const hasTotal = total && total.amount && (total.amount.value || total.amount.value === 0)
   // Check that there is a total
   if (!hasTotal) {
     throw new errorType(`Missing required member(s): amount, label.`);

--- a/packages/react-native-payments/lib/js/helpers/index.js
+++ b/packages/react-native-payments/lib/js/helpers/index.js
@@ -176,13 +176,14 @@ export function validatePaymentMethods(methodData): Array {
   return serializedMethodData;
 }
 
+
 export function validateDisplayItems(displayItems, errorType = Error): void {
   // Check that the value of each display item is a valid decimal monetary value
   if (displayItems) {
     displayItems.forEach((item: PaymentItem) => {
       const amountValue = item && item.amount && item.amount.value;
 
-      if (!amountValue) {
+      if (!amountValue && amountValue !== 0) {
         throw new errorType(`required member value is undefined.`);
       }
 


### PR DESCRIPTION
When using something like a promocode that reduces total price of an item to 0, previous versions of the lib would throw an error, due to a falsey check that showed the total as missing, when really it was just 0. This lets you set the total value of the payment to zero. 