### PR TITLE
fix giturl in podspec file

### DIFF
--- a/packages/react-native-payments/lib/ios/ReactNativePayments.podspec
+++ b/packages/react-native-payments/lib/ios/ReactNativePayments.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   Native Payments (Google and Apple Pay) from React-Native
                    DESC
-  s.homepage     = giturl
+  s.homepage     = "${giturl}"
   s.license      = "MIT"
   s.author       = "Naoufal Kadhom"
   s.platform     = :ios, "7.0"


### PR DESCRIPTION
This fix was done relative of an error that i have when use `pod install` after install the package with npm saying that s.homepage must been a string