### PR TITLE
docs || RN ==> 0.60 support autolinking

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Second, link the native dependencies:
 ```shell
 $ react-native link react-native-payments
 ```
+🚨 Note: If you are using react-native version 0.60 or higher you don't need to link [lottie-react-native](https://github.com/react-native-community/lottie-react-native).
 
 ## Usage
 - [Setting up Apple Pay/Android Pay](#setting-up-apple-payandroid-pay)

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Second, link the native dependencies:
 ```shell
 $ react-native link react-native-payments
 ```
-🚨 Note: If you are using react-native version 0.60 or higher you don't need to link [lottie-react-native](https://github.com/react-native-community/lottie-react-native).
+🚨 Note: If you are using react-native version 0.60 or higher you don't need to link [react-native-payments](https://github.com/naoufal/react-native-payments).
 
 ## Usage
 - [Setting up Apple Pay/Android Pay](#setting-up-apple-payandroid-pay)


### PR DESCRIPTION
[react-native-cli](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md) package by default allow us auto link any packages.

 thanks. Please review this PR 🎉 that's my first PR 🙌

## Compatibility
| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅   |

🙌Happy to contribute with your team🙌

