### PR TITLE
Fix pod install (closes #257)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "react-native-payments",
   "version": "0.8.1",
+  "description": "Welcome to the best and most comprehensive library for integrating payments like Apple Pay and Google Pay into your React Native app.",
   "scripts": {
     "run:packager": "cd examples/native && yarn run:packager",
     "run:ios": "cd examples/native && yarn run:ios",


### PR DESCRIPTION
fix [ISSUE-257](https://github.com/naoufal/react-native-payments/issues/257)
Pod install not working, because `s.summary = pkg["description"]` in **react-native-payments.podspec** is null