### PR TITLE
Bump validator dependency version to remove vulnerability.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-payments",
-  "version": "0.8.0",
+  "version": "0.8.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -11291,9 +11291,9 @@
       }
     },
     "validator": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-7.2.0.tgz",
-      "integrity": "sha512-c8NGTUYeBEcUIGeMppmNVKHE7wwfm3mYbNZxV+c5mlv9fDHI7Ad3p07qfNrn/CvpdkK2k61fOLRO2sTEhgQXmg=="
+      "version": "9.4.1",
+      "resolved": "https://hqo.jfrog.io/artifactory/api/npm/npm/validator/-/validator-9.4.1.tgz",
+      "integrity": "sha1-q/Rm05i1Yc0kMFARLG/x3mzBJmM="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "es6-error": "^4.0.2",
     "uuid": "^3.1.0",
-    "validator": "^7.0.0"
+    "validator": "^9.4.1"
   },
   "devDependencies": {
     "babel-eslint": "^10.1.0",


### PR DESCRIPTION
Take the `validator` package from version ^7.0.0 to ^9.4.1, because it fixes a ReDoS vulnerability as found by snyk.io

![Screen Shot 2021-03-01 at 6 44 49 PM](https://user-images.githubusercontent.com/45402878/109574630-4da58480-7abe-11eb-836b-7521f9e56bed.png)
