### PR TITLE
fix: make abort method on PaymentRequest actually return a Promise<vo…

### DIFF
--- a/js/PaymentRequest/index.js
+++ b/js/PaymentRequest/index.js
@@ -442,8 +442,7 @@ export default class PaymentRequest {
     return this._id;
   }
 
-  // https://www.w3.org/TR/payment-request/#shippingaddress-attribute
-  get shippingAddress(): null | PaymentAddress {
+: null | PaymentAddress {
     return this._shippingAddress;
   }
 
@@ -480,21 +479,18 @@ export default class PaymentRequest {
   abort(): Promise<void> {
     return new Promise((resolve, reject) => {
       // We can't abort if the PaymentRequest isn't shown or already closed
-      if (this._state !== 'interactive') {
-        return reject(new Error('InvalidStateError'));
+      if (this._state !== "interactive") {
+        return reject(new Error("InvalidStateError"));
       }
 
       // Try to dismiss the UI
-      NativePayments.abort(err => {
-        if (err) {
-          return reject(new Error('InvalidStateError'));
-        }
-
-        this._closePaymentRequest();
-
-        // Return `undefined` as proposed in the spec.
-        return resolve(undefined);
-      });
+      NativePayments.abort()
+        .then((_bool) => {
+          this._closePaymentRequest();
+          // Return `undefined` as proposed in the spec.
+          return resolve(undefined);
+        })
+        .catch((_err) => reject(new Error("InvalidStateError")));
     });
   }
 

--- a/js/PaymentRequest/index.js
+++ b/js/PaymentRequest/index.js
@@ -479,8 +479,8 @@ export default class PaymentRequest {
   abort(): Promise<void> {
     return new Promise((resolve, reject) => {
       // We can't abort if the PaymentRequest isn't shown or already closed
-      if (this._state !== "interactive") {
-        return reject(new Error("InvalidStateError"));
+      if (this._state !== 'interactive') {
+        return reject(new Error('InvalidStateError'));
       }
 
       // Try to dismiss the UI
@@ -490,7 +490,7 @@ export default class PaymentRequest {
           // Return `undefined` as proposed in the spec.
           return resolve(undefined);
         })
-        .catch((_err) => reject(new Error("InvalidStateError")));
+        .catch((_err) => reject(new Error('InvalidStateError')));
     });
   }
 


### PR DESCRIPTION
fix: make abort method on PaymentRequest actually return a Promise<void>, thereby properly canceling event listeners

- The `abort` method in `NativePayments` (from `NativeBridge.hs`) returns `Promise<any>`
- The `abort` method in `PaymentRequest/index.js` _is typed as returning `Promise<void>`_; however, it calls `NativePayments.abort` but rather than awaiting the promise, it incorrectly uses the same callback syntax as `NativePayments.abort`, resulting in improper cleanup of the `NativePayments` instance