### PR TITLE
Do not trigger a ShippingOption reset if the original event is actually a ShippingOption change

### DIFF
--- a/js/PaymentRequest/PaymentRequestUpdateEvent.js
+++ b/js/PaymentRequest/PaymentRequestUpdateEvent.js
@@ -127,7 +127,7 @@ export default class PaymentRequestUpdateEvent {
 
           if (
             target._details.shippingOptions &&
-            target._details.shippingOptions.length > 0
+            target._details.shippingOptions.length > 0 &&
             value.shippingOptions &&
             value.shippingOptions.find(op => op.selected)?.id !== target._shippingOption
           ) {

--- a/js/PaymentRequest/PaymentRequestUpdateEvent.js
+++ b/js/PaymentRequest/PaymentRequestUpdateEvent.js
@@ -128,6 +128,8 @@ export default class PaymentRequestUpdateEvent {
           if (
             target._details.shippingOptions &&
             target._details.shippingOptions.length > 0
+            value.shippingOptions &&
+            value.shippingOptions.find(op => op.selected)?.id !== target._shippingOption
           ) {
             target._handleShippingOptionChange({
               selectedShippingOptionId: target._details.shippingOptions[0].id


### PR DESCRIPTION

Fixes #289