### PR TITLE
Import RTClog.h

### DIFF
--- a/ios/ReactNativePayments.m
+++ b/ios/ReactNativePayments.m
@@ -1,6 +1,7 @@
 #import "ReactNativePayments.h"
 #import <React/RCTUtils.h>
 #import <React/RCTEventDispatcher.h>
+#import <React/RCTLog.h>
 
 @implementation ReactNativePayments
 @synthesize bridge = _bridge;


### PR DESCRIPTION
I am using m1 mac and trying to build the app without Rosetta. And the error appears:

<img width="981" alt="截圖 2022-06-11 下午10 57 28" src="https://user-images.githubusercontent.com/16474/173193108-970d1761-09a9-43f7-b06b-605d6695b9b8.png">

This is a small issue and can be fixed by import the RTClog.h
