### PR TITLE
 Use remove function instead of removeSubscription :bug:

### DIFF
--- a/js/PaymentRequest/index.js
+++ b/js/PaymentRequest/index.js
@@ -409,16 +409,12 @@ export default class PaymentRequest {
 
   _removeEventListeners() {
     // Internal Events
-    DeviceEventEmitter.removeSubscription(this._userDismissSubscription);
-    DeviceEventEmitter.removeSubscription(this._userAcceptSubscription);
+    this._userDismissSubscription.remove()
+    this._userAcceptSubscription.remove()
 
     if (IS_IOS) {
-      DeviceEventEmitter.removeSubscription(
-        this._shippingAddressChangeSubscription
-      );
-      DeviceEventEmitter.removeSubscription(
-        this._shippingOptionChangeSubscription
-      );
+      this._shippingAddressChangeSubscription.remove()
+      this._shippingOptionChangeSubscription.remove()
     }
   }
 


### PR DESCRIPTION
Using the remove function instead of removeSubscription, because of deprecation referred in https://github.com/facebook/react-native/issues/32203.
solve issue https://github.com/naoufal/react-native-payments/issues/364