### PR TITLE
Fix Crash when cancelling payment window

### DIFF
--- a/js/PaymentRequest/index.js
+++ b/js/PaymentRequest/index.js
@@ -409,16 +409,12 @@ export default class PaymentRequest {
 
   _removeEventListeners() {
     // Internal Events
-    DeviceEventEmitter.removeSubscription(this._userDismissSubscription);
-    DeviceEventEmitter.removeSubscription(this._userAcceptSubscription);
+    this._userDismissSubscription.remove();
+    this._userAcceptSubscription.remove();
 
     if (IS_IOS) {
-      DeviceEventEmitter.removeSubscription(
-        this._shippingAddressChangeSubscription
-      );
-      DeviceEventEmitter.removeSubscription(
-        this._shippingOptionChangeSubscription
-      );
+      this._shippingAddressChangeSubscription.remove();
+      this._shippingOptionChangeSubscription.remove();
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-payments",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Welcome to the best and most comprehensive library for integrating payments like Apple Pay and Google Pay into your React Native app.",
   "scripts": {
     "run:packager": "cd examples/native && yarn run:packager",


### PR DESCRIPTION
DeviceEventEmitter.removeSubscription was removed with react native 0.70. This is causing the entire app to crash if the payment popup window is closed. Replaced with subscription.remove.

https://github.com/facebook/react-native/issues/34644