### PR TITLE
added support for himyan payment network

### DIFF
--- a/ios/ReactNativePayments.m
+++ b/ios/ReactNativePayments.m
@@ -263,6 +263,10 @@ RCT_EXPORT_METHOD(handleDetailsUpdate: (NSDictionary *)details
         [supportedNetworksMapping setObject:PKPaymentNetworkMada forKey:@"mada"];
     }
     
+    if (iOSVersion >= 18.4) {
+        [supportedNetworksMapping setObject:PKPaymentNetworkHimyan forKey:@"himyan"];
+    }
+    
     // Setup supportedNetworks
     NSArray *jsSupportedNetworks = methodData[@"supportedNetworks"];
     NSMutableArray *supportedNetworks = [NSMutableArray array];


### PR DESCRIPTION
Added support for a new payment network called Himyan, which was recently launched by the Qatar Central Bank for Qatar-issued cards. This enables the plugin to recognize and return the .himyan payment network on supported devices.


More information: https://developer.apple.com/documentation/passkit/pkpaymentnetwork/himyan

